### PR TITLE
feat: implement useNpmMaintainer (#9)

### DIFF
--- a/packages/npm/ROADMAP.md
+++ b/packages/npm/ROADMAP.md
@@ -21,7 +21,7 @@ Hooks built on [`npmjs-api-client`](https://www.npmjs.com/package/npmjs-api-clie
 
 | Hook | Client method | Returns |
 | ---- | ------------- | ------- |
-| `useNpmMaintainer(username)` | `npm.maintainer(username).info()` | `NpmUser` |
+| ✅ [`useNpmMaintainer(username)`](https://github.com/ElJijuna/api-hooks/issues/9) | `npm.maintainer(username).info()` | `NpmUser` |
 | `useNpmMaintainerPackages(username, params?)` | `npm.maintainer(username).packages(params)` | `NpmSearchResult` |
 
 ## Search hooks

--- a/packages/npm/src/hooks/useNpmMaintainer.test.tsx
+++ b/packages/npm/src/hooks/useNpmMaintainer.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { NpmClient, NpmApiError, type NpmUser } from 'npmjs-api-client';
+import { useNpmMaintainer } from './useNpmMaintainer.js';
+
+const mockInfo = jest.fn<() => Promise<NpmUser>>();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest
+    .spyOn(NpmClient.prototype, 'maintainer')
+    .mockReturnValue({
+      info: mockInfo,
+    } as ReturnType<NpmClient['maintainer']>);
+});
+
+const mockUser: NpmUser = {
+  name: 'pilmee',
+  email: 'pilmee@gmail.com',
+};
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe('useNpmMaintainer', () => {
+  it('returns data on success', async () => {
+    mockInfo.mockResolvedValue(mockUser);
+
+    const { result } = renderHook(() => useNpmMaintainer('pilmee'), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toEqual(mockUser);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns error when user has no published packages', async () => {
+    mockInfo.mockRejectedValue(new NpmApiError(404, 'Not Found'));
+
+    const { result } = renderHook(() => useNpmMaintainer('nonexistent-user-xyz'), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeInstanceOf(NpmApiError);
+  });
+
+  it('does not fetch when username is empty', () => {
+    const { result } = renderHook(() => useNpmMaintainer(''), { wrapper });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(mockInfo).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(
+      () => useNpmMaintainer('pilmee', { enabled: false }),
+      { wrapper }
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(mockInfo).not.toHaveBeenCalled();
+  });
+});

--- a/packages/npm/src/hooks/useNpmMaintainer.ts
+++ b/packages/npm/src/hooks/useNpmMaintainer.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { NpmClient, type NpmUser } from 'npmjs-api-client';
+import { npmQueryKeys } from '../keys/npmQueryKeys.js';
+
+export interface UseNpmMaintainerOptions {
+  enabled?: boolean;
+}
+
+export function useNpmMaintainer(
+  username: string,
+  options: UseNpmMaintainerOptions = {}
+): UseQueryResult<NpmUser, Error> {
+  const { enabled = true } = options;
+  const client = useMemo(() => new NpmClient(), []);
+
+  return useQuery<NpmUser, Error>({
+    queryKey: npmQueryKeys.maintainer(username),
+    queryFn: ({ signal }) => client.maintainer(username).info(signal),
+    enabled: enabled && username.length > 0,
+  });
+}

--- a/packages/npm/src/index.ts
+++ b/packages/npm/src/index.ts
@@ -11,7 +11,7 @@ export * from './hooks/useNpmPackageDistTags.js';
 export * from './hooks/useNpmPackageMaintainers.js';
 export * from './hooks/useNpmPackageDownloads.js';
 export * from './hooks/useNpmPackageDownloadRange.js';
-// export * from './hooks/useNpmMaintainer';
+export * from './hooks/useNpmMaintainer.js';
 // export * from './hooks/useNpmMaintainerPackages';
 // export * from './hooks/useNpmSearch';
 export * from './keys/npmQueryKeys.js';

--- a/packages/npm/src/keys/npmQueryKeys.ts
+++ b/packages/npm/src/keys/npmQueryKeys.ts
@@ -12,4 +12,6 @@ export const npmQueryKeys = {
     ['npm', 'package', name, 'downloads', period] as const,
   packageDownloadRange: (name: string, period: string) =>
     ['npm', 'package', name, 'download-range', period] as const,
+  maintainer: (username: string) =>
+    ['npm', 'maintainer', username] as const,
 } as const;


### PR DESCRIPTION
- Add useNpmMaintainer hook returning UseQueryResult<NpmUser, Error>
- Add maintainer key factory to npmQueryKeys